### PR TITLE
feat: add manage subject page and sidebar navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import Navbar from "./component/Navbar";
 import Sidebar from "./component/Sidebar";
+import ManageSubject from "./component/ManageSubject";
 
 function App() {
+  const [activePage, setActivePage] = useState(null);
+
   return (
     <>
       <Navbar />
-      <Sidebar />
+      <Sidebar onMenuClick={setActivePage} />
+      {activePage === 'manageSubject' && <ManageSubject />}
     </>
   );
 }

--- a/frontend/src/component/ManageSubject.jsx
+++ b/frontend/src/component/ManageSubject.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+function ManageSubject() {
+  return (
+    <main className="ml-64 mt-12 p-6 bg-orange-100 min-h-screen">
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold">จัดการรายวิชา</h2>
+          <button className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">
+            เพิ่มรายวิชา
+          </button>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead>
+              <tr className="bg-orange-200 text-left">
+                <th className="px-4 py-2">รหัสรายวิชา</th>
+                <th className="px-4 py-2">ชื่อวิชา</th>
+                <th className="px-4 py-2">หน่วยกิต</th>
+                <th className="px-4 py-2">อาจารย์ผู้สอน</th>
+                <th className="px-4 py-2">จัดการ</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b">
+                <td className="px-4 py-2">5674891</td>
+                <td className="px-4 py-2">ตัวอย่างรายวิชาเพื่อทดสอบการแสดงผล</td>
+                <td className="px-4 py-2">1 (45)</td>
+                <td className="px-4 py-2">xxx</td>
+                <td className="px-4 py-2">
+                  <button className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded">
+                    ลบ
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default ManageSubject;

--- a/frontend/src/component/Sidebar.jsx
+++ b/frontend/src/component/Sidebar.jsx
@@ -1,15 +1,14 @@
 import React from 'react'
 
-function Sidebar() {
+function Sidebar({ onMenuClick }) {
   return (
-    <aside 
+    <aside
       id="sidebar-multi-level-sidebar"
       className="fixed top-0 left-0 z-40 w-64 h-screen transition-transform -translate-x-full sm:translate-x-0"
       aria-label="Sidebar"
     >
       <div className="h-full px-3 py-4 overflow-y-auto bg-yellow-100">
         {/* หัวข้อ */}
-        <h2 className="text-lg font-bold mb-4 px-2">งาน Admin</h2>
         <h2 className="text-lg font-bold mb-4 px-2">งาน Admin</h2>
 
         <ul className="space-y-2 font-medium">
@@ -19,9 +18,13 @@ function Sidebar() {
             </a>
           </li>
           <li>
-            <a href="#" className="a_sidebar group">
+            <button
+              type="button"
+              onClick={() => onMenuClick && onMenuClick('manageSubject')}
+              className="a_sidebar w-full text-left"
+            >
               <span className="span_sidebar">จัดการรายวิชา</span>
-            </a>
+            </button>
           </li>
           <li>
             <a href="#" className="a_sidebar group">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,8 +3,7 @@
 
 @layer utilities{
     .bg-yellow-100{
-        color: #FCDC94;
-
+        background-color: #FCDC94;
     }
 }
 


### PR DESCRIPTION
## Summary
- add ManageSubject page layout with table and add/delete controls
- wire sidebar navigation to show ManageSubject component
- fix sidebar background utility color

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4fd0cd3648323b0df90ea4076c68f