### PR TITLE
Add modal UI to ManageSubject component

### DIFF
--- a/frontend/src/component/ManageSubject.jsx
+++ b/frontend/src/component/ManageSubject.jsx
@@ -1,12 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 
 function ManageSubject() {
+  const [showModal, setShowModal] = useState(false);
+
+  const openModal = () => setShowModal(true);
+  const closeModal = () => setShowModal(false);
+
   return (
-    <main className="ml-64 mt-12 p-6 bg-orange-100 min-h-screen">
+    <>
+      <main className="ml-64 mt-12 p-6 bg-orange-100 min-h-screen">
       <div className="bg-white rounded-lg shadow p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-bold text-black">จัดการรายวิชา</h2>
-          <button className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">
+          <button
+            onClick={openModal}
+            className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded"
+          >
             เพิ่มรายวิชา
           </button>
         </div>
@@ -37,7 +46,33 @@ function ManageSubject() {
           </table>
         </div>
       </div>
-    </main>
+      </main>
+      {showModal && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-lg w-96">
+            <div className="flex items-center justify-between bg-orange-300 px-4 py-2 rounded-t-lg">
+              <h3 className="text-lg font-bold text-black">เพิ่มรายวิชา</h3>
+              <button onClick={closeModal} className="text-black">
+                ×
+              </button>
+            </div>
+            <div className="p-4">
+              <div className="flex justify-end space-x-2 mt-4">
+                <button className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">
+                  บันทึก
+                </button>
+                <button
+                  onClick={closeModal}
+                  className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
+                >
+                  ยกเลิก
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- enable modal state in ManageSubject using `useState`
- open modal via "เพิ่มรายวิชา" button and provide modal markup with overlay
- add close/cancel handlers and styled actions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c50bd6dc188323b317400c63c18fd4